### PR TITLE
Amount is optional according to the guidelines

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,11 @@ const generateQrCode = data => {
 	}
 
 	// > AT-04 Amount of the Credit Transfer in Euro
-	if ('number' !== typeof data.amount) throw new Error('data.amount must be a number.')
-	if (data.amount < 0.01 || data.amount > 999999999.99) {
-		throw new Error('data.amount must be >=0.01 and <=999999999.99.')
+	if ('amount' in data) {
+		if ('number' !== typeof data.amount) throw new Error('data.amount must be a number.')
+		if (data.amount < 0.01 || data.amount > 999999999.99) {
+			throw new Error('data.amount must be >=0.01 and <=999999999.99.')
+		}
 	}
 
 	// > AT-44 Purpose of the Credit Transfer
@@ -77,7 +79,7 @@ const generateQrCode = data => {
 		data.bic,
 		data.name,
 		serializeIBAN(data.iban),
-		'EUR' + data.amount.toFixed(2),
+		data.amount ? 'EUR' + data.amount.toFixed(2) : data.amount,
 		data.purposeCode || '',
 		data.structuredReference || '',
 		data.unstructuredReference || '',


### PR DESCRIPTION
Hey @derhuerst ,

According to the [guidelines](https://www.europeanpaymentscouncil.eu/document-library/guidance-documents/quick-response-code-guidelines-enable-data-capture-initiation) from the readme, the **amount** is optional.

For my use case, it makes sense, mostly I'd like to share just the name/IBAN via a QR and fill in the amount later.
I was testing with my Revolut app, which worked properly without the amount as well.

Let me know what do you think.
Cheers,
Tamas